### PR TITLE
ci: bump Node 20 actions to v6 and revamp Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,54 @@
 version: 2
 updates:
 
-  # Enable minor/patch version updates for go
+  # ---- Python dependencies ----
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Dev/lint/test minor+patch updates batch into one weekly PR.
+      # Dev majors fall outside this group and become individual PRs.
+      python-dev-deps:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
+      # Runtime majors require manual code review.
       - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
+        dependency-type: "production"
+        update-types:
+          - "version-update:semver-major"
+
+  # ---- GitHub Actions ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+    groups:
+      # Minor+patch action bumps batch together. Majors (e.g. Node runtime
+      # bumps like checkout v5->v6) come as individual PRs for review.
+      github-actions-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{secrets.GITHUB_TOKEN}}"
       - name: Approve and enable auto-merge for a PR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.AUTO_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
## Summary
Two related changes on one branch — the immediate fix, and the structural change so this doesn't recur.

**Action runtime bumps** (silences the Node 20 deprecation warning seen on the 3.14 CI run):
- `actions/checkout@v4` → `@v6` (now `node24`)
- `actions/setup-python@v5` → `@v6` (now `node24`)
- `dependabot/fetch-metadata@v2` → `@v3`

**Dependabot config revamp** (`.github/dependabot.yaml`):
- Adds the **`github-actions` ecosystem** — action drift will now surface as PRs automatically. This very bump would have been a Dependabot PR months ago if it had been configured.
- **Groups dev/lint/test pip minor+patch updates** into one weekly PR (`python-dev-deps`). Runtime pip deps stay individual so any prod regression is bisectable.
- **Groups action minor+patch updates** into one weekly PR (`github-actions-minor-patch`). Major action bumps (e.g. Node runtime jumps) come as individual PRs for review.
- **Allows dev pip majors** as individual PRs (so pytest 8→9, mypy 1→2 surface) while still **ignoring runtime pip majors** (still requires hand review for the requests/urllib3 chain).
- Adds labels (`dependencies` + ecosystem) and commit-message prefixes (`chore(deps)` / `chore(deps-dev)` / `chore(actions)`).

**Auto-merge logic in `dependabot-automation.yaml` is unchanged** — the existing `semver-minor` / `semver-patch` gate already produces the right behavior for the new groups (fetch-metadata reports the highest bump in a group, which is at most minor by config) and for individual major PRs (skipped, awaiting human review).

## Resulting behavior

| Update | Today | After this PR |
|---|---|---|
| Action minor/patch | Not detected | Grouped weekly PR, auto-merged |
| Action major (e.g. checkout v6→v7) | Not detected | Individual PR, awaits review |
| Pip dev minor/patch | Individual PRs, auto-merged | Single grouped weekly PR, auto-merged |
| Pip dev major (e.g. pytest 9→10) | Ignored | Individual PR, awaits review |
| Pip runtime minor/patch | Individual PRs, auto-merged | Unchanged |
| Pip runtime major | Ignored | Unchanged |
| Pip security update | Individual PR | Unchanged (security PRs aren't grouped) |

## Test plan
- [x] All four touched YAML files parse via `yaml.safe_load`
- [ ] CI runs cleanly on `actions/checkout@v6` + `actions/setup-python@v6` across `[3.13, 3.14]` with no Node 20 deprecation warning
- [ ] After merge: from Insights → Dependency graph → Dependabot, click "Check for updates" on each ecosystem; confirm grouped PRs appear with the configured labels and commit prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)